### PR TITLE
webpack updates to improve bundle sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ to assume a role allowed to do the upload first.
 after building the runner, you will need to open dist/index.html and manually update the head tag to include the content path and baseURI:
 
 ```
-<head><script>__CONTENT_PATH="<%= fieldUrl('content') %>"</script><meta charset="utf-8"/><title>Webpack App</title><link rel="icon" href="<%= baseURI %>/favicon.ico"><script defer="defer" src="<%= baseURI %>/vendor.bundle.js"></script><script defer="defer" src="<%= baseURI %>/main.bundle.js"></script></head>
+<head><script>__CONTENT_PATH="<%= fieldUrl('content') %>"</script><meta charset="utf-8"/><title><%= fieldUrl('name') %></title><link rel="icon" href="<%= baseURI %>/favicon.ico"><script defer="defer" src="<%= baseURI %>/vendor.bundle.js"></script><script defer="defer" src="<%= baseURI %>/main.bundle.js"></script></head>
 ```
 
 you can then upload the dist folder using the Edit Ancillary Types form.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ to assume a role allowed to do the upload first.
 after building the runner, you will need to open dist/index.html and manually update the head tag to include the content path and baseURI:
 
 ```
-<head><script>__CONTENT_PATH="<%= fieldUrl('content') %>"</script><meta charset="utf-8"/><meta charset="utf-8"/><title>Webpack App</title><link rel="icon" href="<%= baseURI %>/favicon.ico"><script defer="defer" src="<%= baseURI %>/bundle.js"></script></head>
+<head><script>__CONTENT_PATH="<%= fieldUrl('content') %>"</script><meta charset="utf-8"/><title>Webpack App</title><link rel="icon" href="favicon.ico"><script defer="defer" src="<%= baseURI %>/vendor.bundle.js"></script><script defer="defer" src="<%= baseURI %>/main.bundle.js"></script></head>
 ```
 
 you can then upload the dist folder using the Edit Ancillary Types form.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ to assume a role allowed to do the upload first.
 after building the runner, you will need to open dist/index.html and manually update the head tag to include the content path and baseURI:
 
 ```
-<head><script>__CONTENT_PATH="<%= fieldUrl('content') %>"</script><meta charset="utf-8"/><title>Webpack App</title><link rel="icon" href="favicon.ico"><script defer="defer" src="<%= baseURI %>/vendor.bundle.js"></script><script defer="defer" src="<%= baseURI %>/main.bundle.js"></script></head>
+<head><script>__CONTENT_PATH="<%= fieldUrl('content') %>"</script><meta charset="utf-8"/><title>Webpack App</title><link rel="icon" href="<%= baseURI %>/favicon.ico"><script defer="defer" src="<%= baseURI %>/vendor.bundle.js"></script><script defer="defer" src="<%= baseURI %>/main.bundle.js"></script></head>
 ```
 
 you can then upload the dist folder using the Edit Ancillary Types form.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ to assume a role allowed to do the upload first.
 after building the runner, you will need to open dist/index.html and manually update the head tag to include the content path and baseURI:
 
 ```
-<head><script>__CONTENT_PATH="<%= fieldUrl('content') %>"</script><meta charset="utf-8"/><title><%= fieldUrl('name') %></title><link rel="icon" href="<%= baseURI %>/favicon.ico"><script defer="defer" src="<%= baseURI %>/vendor.bundle.js"></script><script defer="defer" src="<%= baseURI %>/main.bundle.js"></script></head>
+<head><script>__CONTENT_PATH="<%= fieldUrl('content') %>"</script><meta charset="utf-8"/><title><%= ancillary.name %></title><link rel="icon" href="<%= baseURI %>/favicon.ico"><script defer="defer" src="<%= baseURI %>/vendor.bundle.js"></script><script defer="defer" src="<%= baseURI %>/main.bundle.js"></script></head>
 ```
 
 you can then upload the dist folder using the Edit Ancillary Types form.

--- a/runner/webpack.config.js
+++ b/runner/webpack.config.js
@@ -10,7 +10,7 @@ if (!librariesHost) {
 
 module.exports = {
   entry: './src/index.ts',
-  devtool: 'inline-source-map',
+  devtool: 'source-map',
   module: {
     rules: [
       {
@@ -33,8 +33,19 @@ module.exports = {
     extensions: ['.ts', '.ts', '.js'],
   },
   output: {
-    filename: 'bundle.js',
+    filename: '[name].bundle.js',
     path: path.resolve(__dirname, 'dist'),
+  },
+  optimization: {
+   splitChunks: {
+     cacheGroups: {
+       vendor: {
+         test: /[\\/]vendor[\\/]/,
+         name: 'vendor',
+         chunks: 'all',
+       },
+     },
+   },
   },
   plugins: [
     new HtmlWebpackPlugin({


### PR DESCRIPTION
Now that we are bundling /vendor ourselves, cloudfront won't let us serve one massive bundle file. This splits main from all the /vendor stuff and relocates the sourcemaps.